### PR TITLE
BVAL-332

### DIFF
--- a/specbook/en/modules/constraint-declaration-validation.xml
+++ b/specbook/en/modules/constraint-declaration-validation.xml
@@ -1576,8 +1576,8 @@ public interface ParameterNameProvider {
           <para>In sub types (be it sub classes/interfaces or interface
           implementations) no parameter constraints must be declared on
           overridden or implemented methods, nor may parameters be marked for
-          cascaded validation (since this would pose a strengthening of
-          preconditions to be fulfilled by the caller).</para>
+          cascaded validation. This would pose a strengthening of
+          preconditions to be fulfilled by the caller.</para>
         </listitem>
 
         <listitem>
@@ -1585,8 +1585,9 @@ public interface ParameterNameProvider {
           in several parallel types of the hierarchy (e.g. two interfaces not
           extending each other, or a class and an interface not implemented by
           said class) no parameter constraints may be declared for that method
-          at all. This again is to avoid an unexpected strengthening of
-          preconditions to be fulfilled by the caller.</para>
+          at all nor parameters be marked for cascaded validation. This again
+          is to avoid an unexpected strengthening of preconditions to be
+          fulfilled by the caller.</para>
         </listitem>
 
         <listitem>
@@ -1595,9 +1596,9 @@ public interface ParameterNameProvider {
           overridden or implemented methods and the return value may be marked
           for cascaded validation. Upon validation, all return value
           constraints of the method in question are validated, wherever they
-          are declared in the hierarchy (since this only poses possibly a
+          are declared in the hierarchy; This only poses possibly a
           strengthening but no weakening of the method's postconditions
-          guaranteed to the caller).</para>
+          guaranteed to the caller.</para>
         </listitem>
 
         <listitem>
@@ -1621,12 +1622,10 @@ public interface ParameterNameProvider {
       providers.</para>
 
       <para>The above rules do not apply when validating constructor
-      constraints. Parameter and return value constraints can be applied to
-      any constructor in the type hierarchy, however, only the constraints
-      defined directly on the validated constructor are evaluated. Constraints
-      defined on super type constructors are not evaluated, even if the
-      constructor in question calls the super type constructor via
-      <methodname>super()</methodname>.</para>
+      constraints as constructors do not override one another. Parameter and
+      return value constraints can be applied to any constructor in the type
+      hierarchy, but only the constraints defined directly on the validated
+      constructor are evaluated.</para>
 
       <section>
         <title>Examples</title>


### PR DESCRIPTION
@gunnarmorling

Built atop https://github.com/beanvalidation/beanvalidation-spec/pull/33

I did change the rules slightly (for parameters) and a made the wording much more concise. I also changed the `@Valid` and `@ConvertGroup` JavaDoc.

Once we agree that's what we want we can squash yours and my commit.

I also think that an example demonstrating those two rules would be useful for people.
