### PR TITLE
BVAL-433 Forbid @ValidatedExecutable on methods of parallel hierarchies

### DIFF
--- a/en/modules/integration.xml
+++ b/en/modules/integration.xml
@@ -336,6 +336,14 @@ public enum ExecutableType {
 }</programlisting>
       </example>
 
+      <para><phrase role="tck-testable">If a sub type overrides/implements a
+      method originally defined in several parallel types of the hierarchy
+      (e.g. two interfaces not extending each other, or a class and an
+      interface not implemented by said class),
+      <classname>@ValidatedExecutable</classname> cannot be placed in the
+      parallel types of the hierarchy.</phrase> This is to avoid an unexpected
+      altering of the post conditions to be guaranteed to the caller.</para>
+
       <note>
         <para>The proper selection of the validated executables is the
         responsibility of the integration between the interception technology


### PR DESCRIPTION
An alternative is to force the same attribute (executable type) across the whole hierarchy. But that looks both complex and bug prone (on the user's perspective)
