### PR TITLE
Maven build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-!# Jakarta Validation specification
+# Jakarta Validation specification
 
 This repository contains the Jakarta Validation specification. 
 For more information on Jakarta Validation and the work in progress,
@@ -14,6 +14,8 @@ file _build.xml_ is located in this directory and all commands are relative to t
 also the default target.
 * Running `ant clean` will clean up output HTML and PDF files.
 * Running `ant render-html` will only build the HTML output (much faster).
+
+The pom.xml in the root directory is an in-progress migration to build with maven. It can be run with `maven clean package`, however Ant is still currently the official build method.
 
 ## Tagging phrases for the TCK
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <!--<ci-user>jenkins</ci-user> No CI integration ported currently-->
     </properties>
 
+
     <repositories>
         <!-- Eclipse Jakarta staging repo is first -->
         <repository>
@@ -254,6 +255,11 @@
                 <configuration>
                     <sourceDirectory>${basedir}</sourceDirectory>
                     <sourceDocumentName>/sources/index.asciidoc</sourceDocumentName>
+                    <!-- TODO switch to this and update asciidoc references to avoid copying
+                        the whole project to generated-docs. The will be a breaking change
+                        with the Ant build.xml
+                    <sourceDirectory>${basedir}/sources</sourceDirectory>
+                    <sourceDocumentName>index.asciidoc</sourceDocumentName>-->
                     <embedAssets>true</embedAssets>
                     <attributes>
                         <source-highlighter>coderay</source-highlighter>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2024 Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~  SPDX-License-Identifier: Apache-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jakarta.validation-spec</artifactId>
+    <groupId>jakarta.validation</groupId>
+    <version>3.1.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+    <name>Jakarta Validation Specification</name>
+
+    <properties>
+        <asciidoctor-maven.version>2.2.4</asciidoctor-maven.version>
+        <asciidoctorj-pdf.version>2.3.10</asciidoctorj-pdf.version>
+
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
+        <bv.revdate>${maven.build.timestamp}</bv.revdate><!-- Replace with fixed date when releasing -->
+        <license>license-evaluation</license><!-- value to use for releasing: license-final -->
+
+        <base.name>validation-specification</base.name>
+        <bv.version>3.1.0-M1</bv.version> <!-- e.g. '2.0.0-RC1' -->
+        <bv.version.spec>3.1</bv.version.spec> <!-- The major.minor of the specification (no service releases) -->
+        <bv.version.qualifier>Draft</bv.version.qualifier> <!-- e.g. ' (Early Draft 1)' - be careful about the space before the qualifier -->
+
+        <hibernate-asciidoctor-theme.version>2.0.0.Final</hibernate-asciidoctor-theme.version>
+        <hibernate-asciidoctor-extensions.version>2.0.0.Final</hibernate-asciidoctor-extensions.version>
+
+        <!--<ci-user>jenkins</ci-user> No CI integration ported currently-->
+    </properties>
+
+    <repositories>
+        <!-- Eclipse Jakarta staging repo is first -->
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Sonatype Nexus Staging</name>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/staging</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <!-- Use Central second -->
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <!-- Use Central first -->
+        <pluginRepository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${bv.version}</version>
+            <classifier>sources</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.infra</groupId>
+            <artifactId>hibernate-asciidoctor-theme</artifactId>
+            <version>${hibernate-asciidoctor-theme.version}</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                  <execution>
+                    <id>unpack-validation-api</id>
+                    <phase>initialize</phase>
+                    <goals>
+                      <goal>unpack-dependencies</goal>
+                    </goals>
+                    <configuration>
+                      <includeGroupIds>jakarta.validation</includeGroupIds>
+                      <includeArtifactIds>jakarta.validation-api</includeArtifactIds>
+                      <outputDirectory>${project.build.directory}/validation-api</outputDirectory>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>unpack-hibernate-asciidoctor-theme</id>
+                    <phase>initialize</phase>
+                    <goals>
+                      <goal>unpack-dependencies</goal>
+                    </goals>
+                    <configuration>
+                      <includeGroupIds>org.hibernate.infra</includeGroupIds>
+                      <includeArtifactIds>hibernate-asciidoctor-theme</includeArtifactIds>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor-maven.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>${asciidoctorj-pdf.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.hibernate.infra</groupId>
+                        <artifactId>hibernate-asciidoctor-extensions</artifactId>
+                        <version>${hibernate-asciidoctor-extensions.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>output-html</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <outputFile>${project.build.directory}/html/${base.name}-${bv.version}.html</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-pdf-doc</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <outputFile>${project.build.directory}/pdf/${base.name}-${bv.version}.pdf</outputFile>
+                            <attributes>
+                                <pdf-theme>hibernate</pdf-theme>
+                                <pdf-themesdir>${project.basedir}/target/hibernate-asciidoctor-theme/theme</pdf-themesdir>
+                                <pdf-fontsdir>${project.basedir}/target/hibernate-asciidoctor-theme/theme/fonts</pdf-fontsdir>                             
+                                <title-page></title-page> <!-- intentionally empty, signals to create title page-->
+                                <!-- Value to use for releasing: jakarta_ee_logo_schooner_color_stacked_default.png[pdfwidth=4.25in,align=right] -->
+                                <logo>jakarta_ee_logo_schooner_color_stacked_default.png[pdfwidth=4.25in,align=right]</logo>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <!-- TODO Enable with hibernate-asciidoctor-extensions 2.0.1+, which should create target/preprocessed/ directory
+                    <execution>
+                        <id>output-preprocessed</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <extensions>
+                                <extension>
+                                    <className>org.hibernate.infra.asciidoctor.extensions.savepreprocessed.SavePreprocessedOutputPreprocessor</className>
+                                </extension>
+                            </extensions>
+                            <backend>html5</backend>
+                        </configuration>
+                    </execution>
+                -->
+                    <execution>
+                        <id>output-docbook</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>docbook</backend>
+                            <outputFile>${project.build.directory}/docbook/index.xml</outputFile>
+                            <extensions>                
+                                <extension>
+                                    <className>org.hibernate.infra.asciidoctor.extensions.customroleblock.DocBookCustomRoleBlockProcessor</className>
+                                    <blockName>tck-testable</blockName>
+                                </extension>
+                                <extension>
+                                    <className>org.hibernate.infra.asciidoctor.extensions.customroleblock.DocBookCustomRoleBlockProcessor</className>
+                                    <blockName>tck-not-testable</blockName>
+                                </extension>
+                                <extension>
+                                    <className>org.hibernate.infra.asciidoctor.extensions.customroleblock.DocBookCustomRoleBlockProcessor</className>
+                                    <blockName>tck-ignore</blockName>
+                                </extension>                         
+                            </extensions>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${basedir}</sourceDirectory>
+                    <sourceDocumentName>/sources/index.asciidoc</sourceDocumentName>
+                    <embedAssets>true</embedAssets>
+                    <attributes>
+                        <source-highlighter>coderay</source-highlighter>
+                        <imagesdir>resources/images</imagesdir>
+                        <tabsize>4</tabsize>
+                        <validation-api-source-dir>${basedir}/target/validation-api/</validation-api-source-dir>
+                        <spec-examples-source-dir>${basedir}/spec-examples/src/test/java/</spec-examples-source-dir>
+                    </attributes>
+                    <extensions>
+                        <extension>
+                            <className>org.hibernate.infra.asciidoctor.extensions.customnumbering.CustomNumberingProcessor</className>
+                        </extension>
+                    </extensions>
+                </configuration>
+            </plugin>       
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This should be a good base for #274. It works with no changes to the asciidoc files.

Builds the spec:
- html
- pdf
- docbook (with tck block processing)

Not all the functionality of the build.xml is ported, including things like the CI variables. I'm not sure what all should be ported vs what can be left in the build.xml. 

The only major piece missing as far as I can tell is building the preprocessed adoc, which works, but will require a new version of hibernate-asciidoctor-extensions with this PR included:
https://github.com/hibernate/hibernate-asciidoctor-extensions/pull/51