### PR TITLE
Enable preprocessed adoc build in maven build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ also the default target.
 * Running `ant clean` will clean up output HTML and PDF files.
 * Running `ant render-html` will only build the HTML output (much faster).
 
-The pom.xml in the root directory is an in-progress migration to build with maven. It can be run with `maven clean package`, however Ant is still currently the official build method.
+The pom.xml in the root directory is an in-progress migration to build with maven. It can be run with `mvn clean package`, however Ant is still currently the official build method.
 
 ## Tagging phrases for the TCK
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <bv.version.qualifier>Draft</bv.version.qualifier> <!-- e.g. ' (Early Draft 1)' - be careful about the space before the qualifier -->
 
         <hibernate-asciidoctor-theme.version>2.0.0.Final</hibernate-asciidoctor-theme.version>
-        <hibernate-asciidoctor-extensions.version>2.0.0.Final</hibernate-asciidoctor-extensions.version>
+        <hibernate-asciidoctor-extensions.version>2.0.1.Final</hibernate-asciidoctor-extensions.version>
 
         <!--<ci-user>jenkins</ci-user> No CI integration ported currently-->
     </properties>
@@ -191,7 +191,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>generate-pdf-doc</id>
+                        <id>output-pdf</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
@@ -209,8 +209,7 @@
                             </attributes>
                         </configuration>
                     </execution>
-                    <!-- TODO Enable with hibernate-asciidoctor-extensions 2.0.1+, which should create target/preprocessed/ directory
-                    <execution>
+                    <execution> 
                         <id>output-preprocessed</id>
                         <phase>generate-resources</phase>
                         <goals>
@@ -225,7 +224,6 @@
                             <backend>html5</backend>
                         </configuration>
                     </execution>
-                -->
                     <execution>
                         <id>output-docbook</id>
                         <phase>generate-resources</phase>


### PR DESCRIPTION
With the changes in Hibernate Asciidoctor Extension version 2.0.1 we can enable the preprocessed output adoc. Includes a few minor fixes as well.